### PR TITLE
solrjs updates for BV-BRC bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,10 +57,14 @@ module.exports = declare([EventEmitter], {
     this.url = url
     this.options = options
     this.agent = undefined
+    this.headers = {}
   },
 
   setAgent: function (agent) {
     this.agent = agent
+  },
+  setHeaders: function(headers) {
+     Object.assign(this.headers, headers)
   },
   streamChunkSize: 2000,
   maxStreamSize: 250000,
@@ -91,7 +95,8 @@ module.exports = declare([EventEmitter], {
 	      method: 'POST',
       headers: {
         accept: 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
+        'Content-Type': 'application/x-www-form-urlencoded',
+	 ...this.headers
       },
       hostname: parsedUrl.hostname,
       port: parsedUrl.port,
@@ -202,7 +207,8 @@ module.exports = declare([EventEmitter], {
         method: 'POST',
         headers: {
           accept: 'application/json',
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/x-www-form-urlencoded',
+	   ...this.headers
         },
         hostname: parsedUrl.hostname,
         port: parsedUrl.port,

--- a/rql.js
+++ b/rql.js
@@ -425,7 +425,7 @@ var handlers = [
   }],
 
   ['keyword', function (query, options) {
-    return query.args[0]
+    return 'text:' + query.args[0]
   }],
 
   // ['distinct', function (query, options) {


### PR DESCRIPTION
Allow passing of an arbitrary header through to solr requests.
Add the definition of the field to be used for keyword searches ("text")